### PR TITLE
Type Information in CSV

### DIFF
--- a/fortigate/Parse-FortiGateRules.ps1
+++ b/fortigate/Parse-FortiGateRules.ps1
@@ -117,10 +117,10 @@ foreach ($line in $modifiedConfig) {
         $date = Get-Date -Format yyyyMMddhhmmss
         if($utf8)
         {
-            $ruleList | Export-Csv -Encoding UTF8 "$workingFolder\rules-$fileName-$vdom-$date-$fileCount.csv";
+            $ruleList | Export-Csv -Encoding UTF8 "$workingFolder\rules-$fileName-$vdom-$date-$fileCount.csv" -NoTypeInformation;
         }
         else {
-            $ruleList | Export-Csv "$workingFolder\rules-$fileName-$vdom-$date-$fileCount.csv";
+            $ruleList | Export-Csv "$workingFolder\rules-$fileName-$vdom-$date-$fileCount.csv" -NoTypeInformation;
         }
         
         $fileCount++;


### PR DESCRIPTION
When exporting to CSV you get #TYPE System.Object on the first line. This -NoTypeInformation will remove this.